### PR TITLE
Modify set_item() to fix flakiness

### DIFF
--- a/json_storage_manager/atomic.py
+++ b/json_storage_manager/atomic.py
@@ -62,6 +62,7 @@ def set_item(filename, item):
             # save the new JSON to the temp file
             json.dump(products_data, temp_file)
             return True
+        json.dump(products_data, temp_file)
         return None  # record already exists
 
 


### PR DESCRIPTION
Multiple tests inside [test_main.py](https://github.com/hefnawi/json-storage-manager/blob/master/tests/test_main.py) were found to be flaky, i.e. test that both pass and fail despite no changes to the code or the tests itself.

Using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin, when the tests were re-run more than once, multiple tests were failing. They run successfully on the first run, but on consequent runs, they don't. Upon looking at the code, the reason was because the JSON file used was being a polluter, i.e. modifying keys in such a way that previous tests fail. To fix most of the failing tests (except 1, `test_set_item`), I just added and extra call to `json.dumps()`.

In general, flaky tests are a pain to fix with regards to locating the root of the actual problem, so it's a good idea to fix them when you detect them. I'm aware that the tests might not be re-run at all, but this change makes the entire module more robust and future-proof so it's just a small fix for you to consider.

To reproduce:

Install pytest-flakefinder by following the instructions [here](https://github.com/dropbox/pytest-flakefinder).
At root directory, `run python3 -m pytest --flake-finder`